### PR TITLE
Add support for compiling templates into CommonJS modules, and use Dust's native whitespace config instead of the optimizer hack.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,9 @@ var dust = require('dustjs-linkedin');
 module.exports = function (opts) {
 	opts = opts || {};
 
-	if (opts.preserveWhitespace) {
-		dust.optimizers.format = function (ctx, node) {
-			return node;
-		};
-	}
-
-	if (opts.amd) {
-		dust.config.amd = true;
-	}
+	dust.config.whitespace = (opts.preserveWhitespace === true);
+	dust.config.amd = (opts.amd === true);
+	dust.config.cjs = (opts.cjs === true);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "compile"
   ],
   "dependencies": {
-    "dustjs-linkedin": "^2.4.0",
+    "dustjs-linkedin": "^2.5.0",
     "gulp-util": "^3.0.0",
     "through2": "^0.6.1"
   },

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,14 @@ Preserve whitespace.
 Type: `boolean`  
 Default: `false`
 
-Compile as AMD modules.
+Compile templates [into AMD modules](http://www.dustjs.com/guides/rendering/#browser-amd-requirejs).
+
+##### cjs
+
+Type: `boolean`
+Default: `false`
+
+Compile templates [into CommonJS modules](http://www.dustjs.com/guides/rendering/#node-load-precompiled-templates).
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -59,7 +59,7 @@ it('should leave whitespace on demand', function (cb) {
 
 	stream.once('data', function (file) {
 		assert(/\\n/.test(file.contents.toString()));
-		cb()
+		cb();
 	});
 
 	stream.write(new gutil.File({
@@ -69,12 +69,28 @@ it('should leave whitespace on demand', function (cb) {
 	}));
 });
 
-it('should should support AMD modules', function (cb) {
+it('should compile templates as AMD modules', function (cb) {
 	var stream = dust({amd: true});
 
 	stream.on('data', function (file) {
 		assert.equal(file.relative, 'fixture/fixture.js');
-		assert(/define\("fixture\\\/fixture.html"/.test(file.contents.toString()));
+		assert(/define\("fixture\\\/fixture\.html"/.test(file.contents.toString()));
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: __dirname + '/fixture/fixture.html',
+		contents: new Buffer('*foo*')
+	}));
+});
+
+it('should compile templates as CommonJS modules', function (cb) {
+	var stream = dust({cjs: true});
+
+	stream.on('data', function (file) {
+		assert.equal(file.relative, 'fixture/fixture.js');
+		assert(/module\.exports=.*?"fixture\\\/fixture\.html"/.test(file.contents.toString()));
 		cb();
 	});
 


### PR DESCRIPTION
As long as we're updating to use Dust config flags, might as well use the others too!

I added support for `dust.config.cjs` (for CommonJS module compiling), and took advantage of the newish (Dust >= 2.5.0) `dust.config.whitespace` flag instead of doing the hacky optimizer clobbering (which was previously the recommendation).