### PR TITLE
override any dust.config value

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,12 @@ module.exports = function (opts) {
 		dust.config.amd = true;
 	}
 
+	if (opts.config) {
+		Object.keys(opts.config).forEach(function (key) {
+			dust.config[key] = opts.config[key];
+		});
+	}
+
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			cb(null, file);

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var dust = require('dustjs-linkedin');
 var objectAssign = require('object-assign');
 var util = require('util');
 
-var setWhitespace = deprecate("preserveWhitespace", "whitespace");
-var setAmd = deprecate("amd", "amd");
+var setWhitespace = deprecate('preserveWhitespace', 'whitespace');
+var setAmd = deprecate('amd', 'amd');
 
 module.exports = function (opts) {
 	opts = opts || {};

--- a/index.js
+++ b/index.js
@@ -2,25 +2,24 @@
 var gutil = require('gulp-util');
 var through = require('through2');
 var dust = require('dustjs-linkedin');
+var objectAssign = require('object-assign');
+var util = require('util');
+
+var setWhitespace = deprecate("preserveWhitespace", "whitespace");
+var setAmd = deprecate("amd", "amd");
 
 module.exports = function (opts) {
 	opts = opts || {};
 
 	if (opts.preserveWhitespace) {
-		dust.optimizers.format = function (ctx, node) {
-			return node;
-		};
+		setWhitespace(opts);
 	}
 
 	if (opts.amd) {
-		dust.config.amd = true;
+		setAmd(opts);
 	}
 
-	if (opts.config) {
-		Object.keys(opts.config).forEach(function (key) {
-			dust.config[key] = opts.config[key];
-		});
-	}
+	objectAssign(dust.config, opts.config);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -47,3 +46,12 @@ module.exports = function (opts) {
 		cb();
 	});
 };
+
+function deprecate(optName, configName) {
+	return util.deprecate(function (opts) {
+		opts.config = opts.config || {};
+		if (!(configName in opts.config)) { // don't overwrite existing config value
+			opts.config[configName] = opts[optName];
+		}
+	}, 'options.' + optName + ' is deprecated, use options.config.' + configName + ' instead');
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "dustjs-linkedin": "^2.4.0",
     "gulp-util": "^3.0.0",
+    "object-assign": "^2.0.0",
     "through2": "^0.6.1"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -48,20 +48,42 @@ dust({
 	}
 });
 ```
+##### config
+
+Type: `object`  
+Default: `{ whitespace: false, amd: false, cjs: false }`
+
+Corresponds to `dust.config`.  Use it to override any dust configuration value.
+
+#### Deprecated
+
+The following have been replaced by `config`:
 
 ##### preserveWhitespace
 
 Type: `boolean`  
 Default: `false`
 
-Preserve whitespace.
+Preserve whitespace.  Deprecated.  Instead use `config.whitespace`:
+
+```js
+dust({
+    config: { whitespace: true }
+});
+```
 
 ##### amd
 
 Type: `boolean`  
 Default: `false`
 
-Compile as AMD modules.
+Compile as AMD modules.  Deprecated.  Instead use `config.amd`:
+
+```js
+dust({
+    config: { amd: true }
+});
+```
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -55,35 +55,26 @@ Default: `{ whitespace: false, amd: false, cjs: false }`
 
 Corresponds to `dust.config`.  Use it to override any dust configuration value.
 
-#### Deprecated
-
-The following have been replaced by `config`:
-
-##### preserveWhitespace
+##### config.whitespace
 
 Type: `boolean`  
 Default: `false`
 
-Preserve whitespace.  Deprecated.  Instead use `config.whitespace`:
+Preserve whitespace.
 
-```js
-dust({
-    config: { whitespace: true }
-});
-```
-
-##### amd
+##### config.amd
 
 Type: `boolean`  
 Default: `false`
 
-Compile as AMD modules.  Deprecated.  Instead use `config.amd`:
+Compile as AMD modules.
 
-```js
-dust({
-    config: { amd: true }
-});
-```
+##### config.cjs
+
+Type: `boolean`  
+Default: `false`
+
+Compile as CommonJS modules.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -63,7 +63,7 @@ it('should leave whitespace on demand', function (cb) {
 
 	stream.once('data', function (file) {
 		assert(/\\n/.test(file.contents.toString()));
-		cb()
+		cb();
 	});
 
 	stream.write(new gutil.File({
@@ -109,7 +109,7 @@ it('should work with deprecated whitespace option', function (cb) {
 
 	stream.once('data', function (file) {
 		assert(/\\n/.test(file.contents.toString()));
-		cb()
+		cb();
 	});
 
 	stream.write(new gutil.File({
@@ -124,8 +124,8 @@ it('should work with deprecated amd option', function (cb) {
 
 	stream.once('data', function (file) {
 		assert.equal(file.relative, 'fixture/fixture.js');
-		assert(/define\("fixture\\\\fixture.html"/.test(file.contents.toString()));
-		cb()
+		assert(/define\("fixture\\\/fixture.html"/.test(file.contents.toString()));
+		cb();
 	});
 
 	stream.write(new gutil.File({

--- a/test.js
+++ b/test.js
@@ -11,8 +11,8 @@ it('should precompile Dust templates', function (cb) {
 	var stream = dust();
 
 	stream.on('data', function (file) {
-		assert.equal(file.relative, 'fixture/fixture.js');
-		assert(/fixture\\\/fixture/.test(file.contents.toString()));
+		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
+		assert(/fixture\\[\\/]fixture/.test(file.contents.toString()));
 		cb();
 	});
 
@@ -77,8 +77,8 @@ it('should should support AMD modules', function (cb) {
 	var stream = dust({ config: { amd: true } });
 
 	stream.on('data', function (file) {
-		assert.equal(file.relative, 'fixture/fixture.js');
-		assert(/define\("fixture\\\/fixture.html"/.test(file.contents.toString()));
+		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
+		assert(/define\("fixture\\[\\/]fixture.html"/.test(file.contents.toString()));
 		cb();
 	});
 
@@ -123,8 +123,8 @@ it('should work with deprecated amd option', function (cb) {
 	var stream = dust({ amd: true });
 
 	stream.once('data', function (file) {
-		assert.equal(file.relative, 'fixture/fixture.js');
-		assert(/define\("fixture\\\/fixture.html"/.test(file.contents.toString()));
+		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
+		assert(/define\("fixture\\[\\/]fixture.html"/.test(file.contents.toString()));
 		cb();
 	});
 

--- a/test.js
+++ b/test.js
@@ -123,7 +123,7 @@ it('should work with deprecated amd option', function (cb) {
 	var stream = dust({ amd: true });
 
 	stream.once('data', function (file) {
-		assert.equal(file.relative, 'fixture\\fixture.js');
+		assert.equal(file.relative, 'fixture/fixture.js');
 		assert(/define\("fixture\\\\fixture.html"/.test(file.contents.toString()));
 		cb()
 	});


### PR DESCRIPTION
This adds support for:

* CommonJS module compilation (see [v2.7.0](https://github.com/linkedin/dustjs/releases/tag/v2.7.0)) via `config.cjs`.
* Any future `dust.config` value.

It deprecates the `preserveWhitespace` and `amd` options in favor of `config.whitespace` and `config.amd`.