### PR TITLE
Add support for cjs build flag to compile Dust.js templates into CommonJS modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function deprecate(optName, configName) {
 
 var setWhitespace = deprecate('preserveWhitespace', 'whitespace');
 var setAmd = deprecate('amd', 'amd');
+var setCommonJs = deprecate('cjs', 'cjs');
 
 module.exports = function (opts) {
 	opts = opts || {};
@@ -28,6 +29,10 @@ module.exports = function (opts) {
 
 	if (opts.amd) {
 		setAmd(opts);
+	}
+
+	if(opts.cjs) {
+		setCommonJs(opts);
 	}
 
 	objectAssign(dust.config, opts.config);


### PR DESCRIPTION
In Dust.js 2.7.1, templates can be compiled into CommonJS modules.  This change is to support the cjs flag in a gulp task.

http://www.dustjs.com/guides/onload/#precompiled-template
https://github.com/linkedin/dustjs/tree/master/examples/commonjs