### PR TITLE
[breaking] use filename without extension instead of relative path as default template name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var util = require('util');
+var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
 var dust = require('dustjs-linkedin');
@@ -46,7 +47,8 @@ module.exports = function (opts) {
 		var filePath = file.path;
 
 		try {
-			var finalName = typeof opts.name === 'function' && opts.name(file) || file.relative;
+            var fullName = typeof opts.name === 'function' && opts.name(file) || file.relative;
+			var finalName = path.extname(fullName) ? fullName.split(path.extname(fullName))[0] : fullName;
 			file.contents = new Buffer(dust.compile(file.contents.toString(), finalName));
 			file.path = gutil.replaceExtension(file.path, '.js');
 			this.push(file);

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (opts) {
 		var filePath = file.path;
 
 		try {
-            var fullName = typeof opts.name === 'function' && opts.name(file) || file.relative;
+			var fullName = typeof opts.name === 'function' && opts.name(file) || file.relative;
 			var finalName = path.extname(fullName) ? fullName.split(path.extname(fullName))[0] : fullName;
 			file.contents = new Buffer(dust.compile(file.contents.toString(), finalName));
 			file.path = gutil.replaceExtension(file.path, '.js');

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (opts) {
 
 		try {
 			var fullName = typeof opts.name === 'function' && opts.name(file) || file.relative;
-			var finalName = path.extname(fullName) ? fullName.split(path.extname(fullName))[0] : fullName;
+			var finalName = path.basename(fullName, path.extname(fullName));
 			file.contents = new Buffer(dust.compile(file.contents.toString(), finalName));
 			file.path = gutil.replaceExtension(file.path, '.js');
 			this.push(file);

--- a/readme.md
+++ b/readme.md
@@ -35,16 +35,16 @@ gulp.task('default', function () {
 ##### name
 
 Type: `function`  
-Default: *Relative template path. Example: `templates/list.html`*
+Default: *Filename. Example: `templates/list.html` => `list`*
 
-You can override the default behavior by supplying a function which gets the current [File](https://github.com/wearefractal/vinyl#constructoroptions) object and is expected to return the name.
+You can override the default behavior by supplying a function which gets the current [File](https://github.com/wearefractal/vinyl#constructoroptions) object and is expected to return the name. File extension is removed as dust#compile expects a template’s name.
 
 Example:
 
 ```js
 dust({
 	name: function (file) {
-		return 'tpl-' + file.relative;
+		return 'custom';
 	}
 });
 ```

--- a/test.js
+++ b/test.js
@@ -18,7 +18,7 @@ it('should precompile Dust templates', function (cb) {
 
 	stream.on('data', function (file) {
 		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
-		assert(/fixture\\[\\/]fixture/.test(file.contents.toString()));
+		assert(/fixture/.test(file.contents.toString()));
 		cb();
 	});
 
@@ -92,7 +92,7 @@ it('should should support AMD modules', function (cb) {
 
 	stream.on('data', function (file) {
 		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
-		assert(/define\("fixture\\[\\/]fixture"/.test(file.contents.toString()));
+		assert(/define\("fixture"/.test(file.contents.toString()));
 		cb();
 	});
 
@@ -142,7 +142,7 @@ it('should work with deprecated amd option', function (cb) {
 
 	stream.once('data', function (file) {
 		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
-		assert(/define\("fixture\\[\\/]fixture"/.test(file.contents.toString()));
+		assert(/define\("fixture"/.test(file.contents.toString()));
 		cb();
 	});
 

--- a/test.js
+++ b/test.js
@@ -92,7 +92,7 @@ it('should should support AMD modules', function (cb) {
 
 	stream.on('data', function (file) {
 		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
-		assert(/define\("fixture\\[\\/]fixture.html"/.test(file.contents.toString()));
+		assert(/define\("fixture\\[\\/]fixture"/.test(file.contents.toString()));
 		cb();
 	});
 
@@ -142,7 +142,7 @@ it('should work with deprecated amd option', function (cb) {
 
 	stream.once('data', function (file) {
 		assert.equal(file.relative.replace(/\\/g, '/'), 'fixture/fixture.js');
-		assert(/define\("fixture\\[\\/]fixture.html"/.test(file.contents.toString()));
+		assert(/define\("fixture\\[\\/]fixture"/.test(file.contents.toString()));
 		cb();
 	});
 


### PR DESCRIPTION
Hi,
I think this plugin should only use the file’s name, not including path and extension, to be used with [`dust.compile`](http://www.dustjs.com/docs/api/#dustcompile), as it seems to be common practice.

For example, it hinders [Adaro](https://github.com/krakenjs/adaro/blob/v1.x/lib/engine.js#L95) from using dust’s cache as it expects the template’s name, not its path.
